### PR TITLE
Fix wm8960-soundcard failure due to `alsactl restore`

### DIFF
--- a/wm8960-soundcard
+++ b/wm8960-soundcard
@@ -30,3 +30,4 @@ do
 done
 
 alsactl restore
+exit 0


### PR DESCRIPTION
A non-zero return code of the `alsactl restore` shall not affect the whole script's return code. Otherwise the service will be failed, and the `systemctl status wm8960-soundcard.service` will show a failure state.